### PR TITLE
DrawNode properties: Change rotation direction from counter-clockwise to clockwise

### DIFF
--- a/axmol/2d/DrawNode.cpp
+++ b/axmol/2d/DrawNode.cpp
@@ -1378,9 +1378,9 @@ void DrawNode::applyLocalTransform(const Vec2* from, Vec2* to, unsigned int coun
             float x = from[i].x - _localPivot.x;
             float y = from[i].y - _localPivot.y;
 
-            // rotate point (counter clockwise)
-            float rx = x * cosRot - y * sinRot;
-            float ry = x * sinRot + y * cosRot;
+            // rotate point (clockwise)
+            float rx = x * cosRot + y * sinRot;
+            float ry = -x * sinRot + y * cosRot;
 
             // translate point back
             x = rx + _localPivot.x;


### PR DESCRIPTION
## Describe your changes

Axmol using clockwise rotation
DrawNode local properties rotation should be have the same behavior: rotation direction clockwise


## Issue ticket number and link


## Checklist before requesting a review
### For each PR
- [ ] Add Copyright if it missed:   
      - `"Copyright (c) 2019-present Axmol Engine contributors (see AUTHORS.md)."`
- [x] I have performed a self-review of my code.
       
   Optional:
   - [ ] I have checked readme and add important infos to this PR.
   - [ ] I have added/adapted some tests too.
          
### For core/new feature PR
- [ ] I have checked readme and add important infos to this PR.
- [ ] I have added thorough tests.

### Axmol 3.x   ------------------------------------------------------------
### For each 3.x PR 
- [ ] Check the '#include "axmol.h"' and replace it with the needed headers.
